### PR TITLE
Add PartialOrd, Ord to Depth

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,5 +1,5 @@
 /// Chroma subsampling format
-#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ChromaSampling {
     /// 4:2:0 = 2x2 pixels of luma per 1 pixel of chroma
     Cs420,
@@ -90,7 +90,7 @@ pub enum TransferCharacteristics {
 
 /// Bit depth (8 = 1 byte, >=10 = 2 bytes)
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum Depth {
     Depth8 = 8,
     Depth10 = 10,

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,6 +1,5 @@
-
 /// Chroma subsampling format
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum ChromaSampling {
     /// 4:2:0 = 2x2 pixels of luma per 1 pixel of chroma
     Cs420,
@@ -49,7 +48,6 @@ pub enum ColorPrimaries {
     /// EBU Tech. 3213-E
     EBU3213 = 22,
 }
-
 
 /// Gamma correction, essentially.
 /// As defined by “Transfer characteristics” section of ISO/IEC 23091-4/ITU-TH.273.


### PR DESCRIPTION
It's nice being able to see if bit depth is lower or higher as if it was an int enum since it's basically a scale.