### PR TITLE
feat: re-export rgb::prelude for trait access

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,3 +36,6 @@ pub use rgb::Rgb as RGB;
 /// An RGBA pixel (from the [`rgb`] crate)
 #[doc(hidden)]
 pub use rgb::Rgba as RGBA;
+
+/// Re-export of rgb prelude for trait access (e.g., `.map()` method on pixels)
+pub use rgb::prelude;


### PR DESCRIPTION
## Summary

Re-exports the rgb crate's prelude module so that users of yuv can access traits like `Pixel` (which provides the `.map()` method) without needing to add rgb as a direct dependency.

## Problem

When using `yuv::RGB` or `yuv::RGBA` types, calling `.map()` requires the `Pixel` trait (or `ComponentMap` in older versions) to be in scope. Currently, users need to add rgb as a dependency and import the trait themselves.

This becomes a breaking change issue when rgb 0.8.91 is released, as the trait providing `.map()` changes from `ComponentMap` to `Pixel`.

## Solution

Re-export `rgb::prelude` so users can:

```rust
use yuv::prelude::*;
let half = pixel.map(|c| c / 2);
```

The prelude approach is forward-compatible - it works with both rgb 0.8.x (exports `ComponentMap`) and rgb 0.8.91+ (exports `Pixel`).

## Related

This helps downstream crates like `aom-decode` which use `yuv::RGB` types with `.map()`.